### PR TITLE
Adding support for PORT env var

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: lein run

--- a/src/zk_web/conf.clj
+++ b/src/zk_web/conf.clj
@@ -1,5 +1,6 @@
 (ns zk-web.conf
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [zk-web.util :as u])
   (:import [java.io File PushbackReader]))
 
 (defn- valid-conf-file?
@@ -15,10 +16,15 @@
 
 (defn load-conf []
   "load the config from ~/.zk-web-conf.clj or conf/zk-web-conf.clj"
-  (let [home-conf (str (get (System/getenv) "HOME") File/separator ".zk-web-conf.clj")
-        pwd-conf "conf/zk-web-conf.clj"]
-    (or (load-conf-file home-conf) (load-conf-file pwd-conf)
-        {
-         :server-port 8080
-         :users {"admin" "hello"}
-         })))
+  (let [home-conf (str (System/getenv "HOME") File/separator ".zk-web-conf.clj")
+        pwd-conf "conf/zk-web-conf.clj"
+        env-port (u/str->int (System/getenv "PORT"))
+        conf     (or (load-conf-file home-conf) (load-conf-file pwd-conf)
+                  {
+                   :server-port 8080
+                   :users {"admin" "hello"}
+                  })]
+        (if env-port
+          (assoc conf :server-port env-port)
+          conf)))
+

--- a/src/zk_web/util.clj
+++ b/src/zk_web/util.clj
@@ -48,3 +48,6 @@
    (= path "/") "/"
    :default (let [path (if (.endsWith path "/") (drop-last path) path)]
               (apply str (drop-last-while #(not= % \/) path)))))
+
+(defn str->int [string]
+  (Integer. (re-find  #"\d+" string )))


### PR DESCRIPTION
Here is a simple commit for adding support for a PORT env

I have also added a sample [Foreman](https://github.com/ddollar/foreman) for running things as well. 

The ENV VAR overrides any current configuration.

I tested this code with 
- `foreman start` - the app boots with port 5000
- `ENV=4900 lein run` - the app boots with port 4900

