### PR TITLE
Adding support for DEFAULT_NODE env var

### DIFF
--- a/src/zk_web/conf.clj
+++ b/src/zk_web/conf.clj
@@ -19,12 +19,17 @@
   (let [home-conf (str (System/getenv "HOME") File/separator ".zk-web-conf.clj")
         pwd-conf "conf/zk-web-conf.clj"
         env-port (u/str->int (System/getenv "PORT"))
+        env-node (str (System/getenv "DEFAULT_NODE"))
         conf     (or (load-conf-file home-conf) (load-conf-file pwd-conf)
                   {
                    :server-port 8080
                    :users {"admin" "hello"}
+                   :default-node ""
                   })]
         (if env-port
           (assoc conf :server-port env-port)
+          conf)
+        (if env-node
+          (assoc conf :default-node env-node)
           conf)))
 


### PR DESCRIPTION
Similar to #14 it's useful to set `default-node` from an environment variable.