### PR TITLE
Add base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ zk-web is also easy to configurate. It reads `$HOME/.zk-web-conf.clj` or `conf/z
          ;; you can add more
          }
  :default-node "localhost:2181/my-start-node" ;; optional
+ :base-url "/prefix" ;; optional
  }
 ```
 
@@ -55,6 +56,7 @@ zk-web is also easy to configurate. It reads `$HOME/.zk-web-conf.clj` or `conf/z
 * @lra 
 * @lispmind 
 * @killme2008 
+* @thorhs
 
 
 ## License

--- a/conf/zk-web-conf.clj
+++ b/conf/zk-web-conf.clj
@@ -2,4 +2,5 @@
  :server-port 8080
  :users {"admin" "hello"}
  :default-node ""
+ :base-uri "/"
 }

--- a/src/zk_web/server.clj
+++ b/src/zk_web/server.clj
@@ -9,6 +9,8 @@
 
 (defn -main [& m]
   (let [mode (keyword (or (first m) :dev))
-        port (:server-port (conf/load-conf))]
+        port (:server-port (conf/load-conf))
+        base-url (:base-url (conf/load-conf))]
     (server/start port {:mode mode
-                        :ns 'zk-web})))
+                        :ns 'zk-web
+                        :base-url base-url})))


### PR DESCRIPTION
I've created a small patch to add the option of a base URL.  I'm running behind a reverse proxy and found this lacking.

This was a simple two line code, and I have verified manually that it works with or without the base-url option in the config file.  I've never touched clojure before, and I fear I may be calling the load_config twice.  That is fine by me since it is only done at startup, but should probably be optimised.

This patch addresses #28 