### PR TITLE
Incorrect escaping of z node values #35

### DIFF
--- a/src/zk_web/pages.clj
+++ b/src/zk_web/pages.clj
@@ -142,7 +142,7 @@
      [:div.alert.alert-error "God, zookeeper returns NULL!"]
      [:div.well
       [:p {:style "word-break:break-all;"}
-       (str/replace (bytes->str data) #"\n" "<br>")]])])
+       (str/replace (bytes->str data) #"\n|<|>" {"\n" "<br>" "<" "&lt;" ">" "&gt;"})]])])
 
 (defpartial create-modal [path]
   [:div#createModal.modal.hide.fade


### PR DESCRIPTION
I have added small fix: escape "<" and ">".
those simbols shoud shows on Node Data

https://github.com/qiuxiafei/zk-web/issues/35