### PR TITLE
Sort zookeeper nodes, print mtime & ctime human-readable too and copy to clipboard

### DIFF
--- a/build-pkg-with-fpm.sh
+++ b/build-pkg-with-fpm.sh
@@ -4,7 +4,7 @@
 set -x -e
 
 name=zk-web
-version="0.1.0-SNAPSHOT"
+version="0.2.0"
 packaging_version=""
 
 maintainer="${USER}@localhost"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zk-web "0.1.0-SNAPSHOT"
+(defproject zk-web "0.2.0"
             :description "FIXME: write this!"
             :dependencies [[org.clojure/clojure "1.4.0"]
                            [noir "1.3.0-beta3"]

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,6 @@
             :dependencies [[org.clojure/clojure "1.4.0"]
                            [noir "1.3.0-beta3"]
                            [com.netflix.curator/curator-framework "1.1.16"]
-                           [com.netflix.curator/curator-test "1.1.16"]]
+                           [com.netflix.curator/curator-test "1.1.16"]
+                           [clj-time "0.14.4"]]
             :main zk-web.server)

--- a/resources/public/css/bootstrap.css
+++ b/resources/public/css/bootstrap.css
@@ -228,6 +228,23 @@ a:hover {
   width: 940px;
 }
 
+.float-right {
+  float: right;
+  align-content: right;
+}
+
+
+.float-left {
+  float: left;
+  align-content: left;
+}
+
+.clipboard-input {
+  display: none; 
+  position: relative; 
+  left: -10000px;
+}
+
 .span12 {
   width: 940px;
 }

--- a/resources/public/js/functions.js
+++ b/resources/public/js/functions.js
@@ -1,0 +1,5 @@
+function copyToClipboard() {
+    var text = document.getElementById("clipboard-input");
+    text.select();
+    document.execCommand("copy");
+}

--- a/src/zk_web/pages.clj
+++ b/src/zk_web/pages.clj
@@ -231,7 +231,7 @@
     (if (nil? cli)
       (resp/redirect "/")
       (layout
-       (let [children (zk/ls cli path)
+       (let [children (sort (zk/ls cli path))
              stat (zk/stat cli path)
              data (zk/get cli path)]
          [:div

--- a/src/zk_web/pages.clj
+++ b/src/zk_web/pages.clj
@@ -89,6 +89,7 @@
     [:title "ZK-Web | Make zookeeper simpler"]
     (include-js "/js/jquery.js")
     (include-js "/js/bootstrap.js")
+    (include-js "/js/functions.js")
     (include-css "/css/bootstrap.css")]
    [:body
     [:div.container {:style "padding:0px 0px 40px 0px;"}
@@ -98,11 +99,16 @@
 
 ;; page elements
 
+(def COPY-TO-CLIPBOARD-SVG "M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z")
+
 (defpartial nav-bar [path]
   (let [[node-seq link-seq] (nodes-parents-and-link path)]
     [:ul.breadcrumb.span12
-     (interleave (repeat [:i.icon-chevron-right])
-                 (map (fn [l n] [:li (node-link l n)]) link-seq  node-seq))]))
+     [:div.float-left (interleave (repeat [:i.icon-chevron-right]) (map (fn [l n] [:li (node-link l n)]) link-seq  node-seq))]
+     [:div.float-right
+       [:input.clipboard-input {:type "text" :id "clipboard-input" :value path}]
+       [:svg {:viewBox "0 0 14 16" :version "1.1" :width "14" :height "16" :aria-hidden "true" :onclick "copyToClipboard()"}
+         [:path {:fill-rule "evenodd" :d COPY-TO-CLIPBOARD-SVG}]]]]))
 
 (defpartial node-children [parent children]
   (let [parent (if (.endsWith parent "/")


### PR DESCRIPTION
This pull request contains three improvements that were bothering me for quite some time:

1. The nodes in the **Children** section are now sorted by their name.
1. The values in the **Node Stat** section are now printed by the key
1. In the **Node Stat** section, I've added fields `ctime-pretty` and `mtime-pretty` that are human-readable representations of `ctime` and `mtime`
1. There is a "copy to clipboard" button in the headline of the page now. Once clicked upon, the path of the current zookeeper node is copied to clipboard.

Please let me know what you think. And if you like it, please merge it :)