### PR TITLE
Fix node in URL not URLEncoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.iml
 tmp/
 *.deb
+pom.xml

--- a/src/zk_web/pages.clj
+++ b/src/zk_web/pages.clj
@@ -6,6 +6,7 @@
             [noir.response :as resp]
             [noir.request :as req]
             [clojure.string :as str])
+  (:import (java.net URLEncoder))
   (:use [noir.core]
         [zk-web.util]
         [hiccup page form element core]))
@@ -15,7 +16,7 @@
 (defn node-link
   "Return http link to node page"
   [node text]
-  [:a {:href (str "/node?path=" node)} text])
+  [:a {:href (str "/node?path=" (string->urlencoded node))} text])
 
 (defn nodes-parents-and-link
   "Return name parents and there links"

--- a/src/zk_web/util.clj
+++ b/src/zk_web/util.clj
@@ -1,6 +1,7 @@
 (ns zk-web.util
   (:require [noir.session :as session])
-  (:import [java.nio.charset Charset]))
+  (:import [java.nio.charset Charset]
+           [java.net URLEncoder]))
 
 (defn bytes->str
   "Convert byte[] to String"
@@ -8,6 +9,11 @@
   (if bytes
     (String. bytes (Charset/forName "UTF-8"))
     ""))
+
+(defn string->urlencoded
+  "Convert string to a valid URL string."
+  [string]
+  (URLEncoder/encode string "UTF-8"))
 
 (defn normalize-path
   "fix the path to normalized form"


### PR DESCRIPTION
If a node contains characters that means in URL(like `&/=`) will cause an error that could not found node.

Here is a test url: `http://localhost:8080/node?path=/a=b&version=1`, the node path is `/a=b&version=1`, the correct url should be: `%2Fa%3Db%26version%3D1`.