### PR TITLE
Fixed not honored config file's default_node property

### DIFF
--- a/src/zk_web/conf.clj
+++ b/src/zk_web/conf.clj
@@ -1,6 +1,7 @@
 (ns zk-web.conf
   (:require [clojure.java.io :as io]
-            [zk-web.util :as u])
+            [zk-web.util :as u]
+            [clojure.string :as s])
   (:import [java.io File PushbackReader]))
 
 (defn- valid-conf-file?
@@ -29,7 +30,7 @@
         (if env-port
           (assoc conf :server-port env-port)
           conf)
-        (if env-node
+        (if (not (s/blank? env-node))
           (assoc conf :default-node env-node)
           conf)))
 


### PR DESCRIPTION
- Enhanced validation of DEFAULT_NODE environment variable
---

## Description

Config file's 'default_node' property doesn't work at current version.
Although no env var `DEFAULT_NODE` set, config loader is trying to set empty string as `default_node` after loading config file.
As a result, config file's `default_node` is ignored.

So added validation of env var `DEFAULT_NODE` variable.

Related issue: https://github.com/qiuxiafei/zk-web/issues/39